### PR TITLE
add mcrouter and memcached debug and management tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ RUN apk add --no-cache ruby ruby-dev \
       wget \
       perl \
       bash \
+      socat \
+      rsync \
    \
    && mkdir -p /var/spool/mcrouter \
    && cd /opt/mcfly \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,11 @@ RUN apk add --no-cache ruby ruby-dev \
       zlib zlib-dev \
       libmemcached-libs libmemcached-dev \
       cyrus-sasl cyrus-sasl-dev \
+      ngrep \
+      tcpdump \
+      wget \
+      perl \
+      bash \
    \
    && mkdir -p /var/spool/mcrouter \
    && cd /opt/mcfly \
@@ -17,6 +22,8 @@ RUN apk add --no-cache ruby ruby-dev \
    \
    && apk del build-base \
       ruby-dev \
+   && wget https://raw.githubusercontent.com/memcached/memcached/master/scripts/memcached-tool -O /usr/bin/memcached-tool \
+   && chmod a+x /usr/bin/memcached-tool \
    && rm -rf /tmp/* /var/tmp/* /var/cache/apk/*
 
 ENTRYPOINT ["/opt/mcfly/mcfly"]


### PR DESCRIPTION
Given the fashion in which this tool might normally be used, it could be helpful to some to have a few extra debugging tools handy on the image;

  * `bash`
  * `ngrep`
  * `netcat`
  * `socat`
  * `memcached-tools`
  * `tcpdump`
  * `perl`
  * `rsync`